### PR TITLE
Address Player's qualms with the current API

### DIFF
--- a/fabric-dimensions-v1/build.gradle
+++ b/fabric-dimensions-v1/build.gradle
@@ -3,4 +3,6 @@ version = getSubprojectVersion(project, "0.1.0")
 
 dependencies {
 	compile project(path: ':fabric-api-base', configuration: 'dev')
+	compile project(path: ':fabric-networking-v0', configuration: 'dev')
+	compile project(path: ':fabric-registry-sync-v0', configuration: 'dev')
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/EntityPlacer.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/EntityPlacer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.api.dimension;
 
 import net.minecraft.block.pattern.BlockPattern;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/EntityPlacer.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/EntityPlacer.java
@@ -31,18 +31,18 @@ import net.minecraft.util.math.Direction;
 @FunctionalInterface
 public interface EntityPlacer {
 
-    /**
-     * Handles the placement of an entity going to a dimension.
-     *
-     * <p> This method may have side effects such as the creation of a portal in the target dimension,
-     * or the creation of a chunk loading ticket.
-     *
-     * @param portalDir the direction the portal is facing, meaningless if no portal was used
-     * @param horizontalOffset the horizontal offset of the entity relative to the front top left corner of the portal, meaningless if no portal was used
-     * @param verticalOffset  the vertical offset of the entity relative to the front top left corner of the portal, meaningless if no portal was used
-     * @return a teleportation target, or {@code null} to fall back to further handling
-     * @apiNote When this method is called, the entity's world is its source dimension.
-     */
-    /* @Nullable */
-    BlockPattern.TeleportTarget placeEntity(Entity teleported, ServerWorld destination, Direction portalDir, double horizontalOffset, double verticalOffset);
+	/**
+	 * Handles the placement of an entity going to a dimension.
+	 *
+	 * <p> This method may have side effects such as the creation of a portal in the target dimension,
+	 * or the creation of a chunk loading ticket.
+	 *
+	 * @param portalDir        the direction the portal is facing, meaningless if no portal was used
+	 * @param horizontalOffset the horizontal offset of the entity relative to the front top left corner of the portal, meaningless if no portal was used
+	 * @param verticalOffset   the vertical offset of the entity relative to the front top left corner of the portal, meaningless if no portal was used
+	 * @return a teleportation target, or {@code null} to fall back to further handling
+	 * @apiNote When this method is called, the entity's world is its source dimension.
+	 */
+	/* @Nullable */
+	BlockPattern.TeleportTarget placeEntity(Entity teleported, ServerWorld destination, Direction portalDir, double horizontalOffset, double verticalOffset);
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensionType.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensionType.java
@@ -29,17 +29,17 @@ import net.minecraft.world.dimension.DimensionType;
 import java.util.function.BiFunction;
 
 /**
- * Fabric version of {@link DimensionType}.
- * DimensionType is a registry wrapper for Dimension.
- * Stores a default {@link EntityPlacer} which is used to place entities in the world when they join.
- * Instances of this class get their raw ids automatically assigned.
+ * An extended version of {@link DimensionType} with automatic raw id management and default placement settings.
+ * {@code FabricDimensionType} instances are constructed and registered through a {@link Builder}.
+ *
+ * @see #builder()
+ * @see #getDefaultPlacement()
+ * @see #getDesiredRawId()
  */
 public final class FabricDimensionType extends DimensionType {
 	private final EntityPlacer defaultPlacement;
 	private int desiredRawId;
-	/**
-	 * The fixed raw id for this dimension type, set through reflection
-	 */
+	/** The fixed raw id for this dimension type, set through reflection */
 	private int fixedRawId;
 
 	/**
@@ -114,6 +114,8 @@ public final class FabricDimensionType extends DimensionType {
 	 * <p>Builder instances can be reused; it is safe to call {@link #buildAndRegister(Identifier)} multiple
 	 * times (with different identifiers) to build and register multiple dimension types in series.
 	 * Each new dimension type uses the settings of the builder at the time it is built.
+	 *
+	 * @see FabricDimensionType#builder()
 	 */
 	public static final class Builder {
 		private EntityPlacer defaultPlacer;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensionType.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensionType.java
@@ -37,7 +37,9 @@ import java.util.function.BiFunction;
 public final class FabricDimensionType extends DimensionType {
 	private final EntityPlacer defaultPlacement;
 	private int desiredRawId;
-	/** The fixed raw id for this dimension type, set through reflection */
+	/**
+	 * The fixed raw id for this dimension type, set through reflection
+	 */
 	private int fixedRawId;
 
 	/**
@@ -119,7 +121,8 @@ public final class FabricDimensionType extends DimensionType {
 		private int desiredRawId = 0;
 		private boolean skyLight = true;
 
-		private Builder() { }
+		private Builder() {
+		}
 
 		/**
 		 * Set the default placer used when teleporting entities to dimensions of the built type.
@@ -158,7 +161,7 @@ public final class FabricDimensionType extends DimensionType {
 		 * If this method is not called, the value defaults to {@code true}.
 		 *
 		 * @param skyLight {@code true} if the dimension of the built type should use skylight,
-		 * 		{@code false} otherwise
+		 *                 {@code false} otherwise
 		 * @return this {@code Builder} object
 		 */
 		public Builder skyLight(boolean skyLight) {

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensionType.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensionType.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.api.dimension;
 
 import com.google.common.base.Preconditions;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensionType.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensionType.java
@@ -1,89 +1,202 @@
 package net.fabricmc.fabric.api.dimension;
 
+import com.google.common.base.Preconditions;
 import net.minecraft.entity.Entity;
+import net.minecraft.server.world.ServerWorld;
 import net.minecraft.util.Identifier;
+import net.minecraft.util.math.Direction;
 import net.minecraft.util.registry.Registry;
 import net.minecraft.world.World;
 import net.minecraft.world.dimension.Dimension;
 import net.minecraft.world.dimension.DimensionType;
 
-import java.util.Objects;
 import java.util.function.BiFunction;
 
 /**
- * Fabric version of DimensionType.
+ * Fabric version of {@link DimensionType}.
  * DimensionType is a registry wrapper for Dimension.
  * Stores a default {@link EntityPlacer} which is used to place entities in the world when they join.
  * Instances of this class get their raw ids automatically assigned.
  */
-public class FabricDimensionType extends DimensionType {
-    private final Identifier identifier;
-    private final EntityPlacer defaultPlacement;
-    private int fixedId;
+public final class FabricDimensionType extends DimensionType {
+	private final EntityPlacer defaultPlacement;
+	private int desiredRawId;
+	/** The fixed raw id for this dimension type, set through reflection */
+	private int fixedRawId;
 
-    /**
-     * @param name          a unique name used both for the dimension suffix and the save directory
-     * @param factory       a function creating new {@code Dimension} instances
-     * @param defaultPlacer a default {@code EntityPlacer} for the dimension
-     * @param hasSkyLight   {@code true} if the dimension type should have skylight like the overworld,
-     *                      {@code false} otherwise
-     * @throws NullPointerException if any of the parameters is null
-     */
-    public FabricDimensionType(Identifier name, BiFunction<World, DimensionType, ? extends Dimension> factory, EntityPlacer defaultPlacer, boolean hasSkyLight) {
-        // Pass an arbitrary raw id that does not map to any vanilla dimension. That id should never get used.
-        super(3, name.getNamespace() + "_" + name.getPath(), "DIM_" + name.getNamespace() + "_" + name.getPath(), factory, hasSkyLight);
-        Objects.requireNonNull(factory);
-        this.identifier = name;
-        this.defaultPlacement = Objects.requireNonNull(defaultPlacer);
-    }
+	/**
+	 * Returns a new {@link Builder}.
+	 */
+	public static Builder builder() {
+		return new FabricDimensionType.Builder();
+	}
 
-    /**
-     * Sets this dimension's fixed id, replacing the vanilla raw dimension id.
-     *
-     * @param fixedId the new raw id for this dimension type
-     * @apiNote Mods that used to have a dimension with a manually set id
-     * may use this method to set a default id corresponding to the old one,
-     * so as not to break compatibility with old worlds.
-     */
-    public void setFixedId(int fixedId) {
-        this.fixedId = fixedId;
-    }
+	/**
+	 * @param suffix        the string suffix unique to the dimension type
+	 * @param saveDir       the name of the save directory for the dimension type
+	 * @param factory       a function creating new {@code Dimension} instances
+	 * @param defaultPlacer a default {@code EntityPlacer} for the dimension
+	 * @param hasSkyLight   {@code true} if the dimension type should have skylight like the overworld,
+	 *                      {@code false} otherwise
+	 * @see #builder()
+	 */
+	private FabricDimensionType(String suffix, String saveDir, BiFunction<World, DimensionType, ? extends Dimension> factory, EntityPlacer defaultPlacer, boolean hasSkyLight) {
+		// Pass an arbitrary raw id that does not map to any vanilla dimension. That id should never get used.
+		super(3, suffix, saveDir, factory, hasSkyLight);
+		this.defaultPlacement = defaultPlacer;
+	}
 
-    /**
-     * Return the current raw id for this dimension type.
-     * The returned id is guaranteed to be unique and persistent in a save,
-     * as well as synchronized between a server and its connected clients.
-     *
-     * @return the current raw id for this dimension type
-     * @implNote the raw id may change when connecting to a different server
-     * or opening a new save.
-     * @see #setFixedId(int)
-     */
-    @Override
-    public int getRawId() {
-        if (this.fixedId == 0) {
-            return Registry.DIMENSION.getRawId(this) + -1;
-        }
-        return this.fixedId;
-    }
+	/**
+	 * Return the desired raw id of this dimension type.
+	 *
+	 * @return the preferred raw id of this dimension type
+	 * @see Builder#desiredRawId(int)
+	 */
+	public int getDesiredRawId() {
+		return desiredRawId;
+	}
 
-    /**
-     * Return the identifier used to name this dimension. The identifier may be reused for registration.
-     *
-     * @return the identifier used to name this dimension
-     */
-    public Identifier getUniqueName() {
-        return identifier;
-    }
+	/**
+	 * Return the current raw id for this dimension type.
+	 *
+	 * <p> The returned id is guaranteed to be unique and persistent in a save,
+	 * as well as synchronized between a server and its connected clients.
+	 * It may change when connecting to a different server or opening a new save.
+	 *
+	 * @return the current raw id for this dimension type
+	 * @see #getDesiredRawId()
+	 */
+	@Override
+	public int getRawId() {
+		return this.fixedRawId;
+	}
 
-    /**
-     * Return the default placement logic for this dimension. The returned placer
-     * never returns {@code null} when called.
-     *
-     * @return the default placement logic for this dimension
-     * @see FabricDimensions#teleport(Entity, DimensionType, EntityPlacer)
-     */
-    public EntityPlacer getDefaultPlacement() {
-        return this.defaultPlacement;
-    }
+	/**
+	 * Return the default placement logic for this dimension. The returned placer
+	 * never returns {@code null} when called.
+	 *
+	 * @return the default placement logic for this dimension
+	 * @see FabricDimensions#teleport(Entity, DimensionType, EntityPlacer)
+	 */
+	public EntityPlacer getDefaultPlacement() {
+		return this.defaultPlacement;
+	}
+
+	/**
+	 * A builder for creating and registering {@code FabricDimensionType} instances. Example: <pre>   {@code
+	 *
+	 *   public static final FabricDimensionType MY_DIMENSION
+	 *       = FabricDimensionType.builder()
+	 *           .defaultPlacement((oldEntity, destination, portalDir, horizontalOffset, verticalOffset) ->
+	 *           		new BlockPattern.TeleportTarget(new Vec3d(0, 100, 0), teleported.getVelocity(), 0))
+	 *           .factory(MyDimension::new)
+	 *           .skyLight(true)
+	 *           .buildAndRegister();}</pre>
+	 *
+	 * <p>Builder instances can be reused; it is safe to call {@link #buildAndRegister(Identifier)} multiple
+	 * times (with different identifiers) to build and register multiple dimension types in series.
+	 * Each new dimension type uses the settings of the builder at the time it is built.
+	 */
+	public static final class Builder {
+		private EntityPlacer defaultPlacer;
+		private BiFunction<World, DimensionType, ? extends Dimension> factory;
+		private int desiredRawId = 0;
+		private boolean skyLight = true;
+
+		private Builder() { }
+
+		/**
+		 * Set the default placer used when teleporting entities to dimensions of the built type.
+		 * The default placer must be set before building a dimension type.
+		 *
+		 * <p> A dimension type's default placer must never return {@code null} when its
+		 * {@link EntityPlacer#placeEntity(Entity, ServerWorld, Direction, double, double) placeEntity} method
+		 * is called.
+		 *
+		 * @param defaultPlacer a default entity placer for dimensions of the built type
+		 * @return this {@code Builder} object
+		 * @throws NullPointerException if {@code defaultPlacer} is {@code null}
+		 */
+		public Builder defaultPlacer(EntityPlacer defaultPlacer) {
+			Preconditions.checkNotNull(defaultPlacer);
+			this.defaultPlacer = defaultPlacer;
+			return this;
+		}
+
+		/**
+		 * Set the factory used to create new {@link Dimension} instances of the built type.
+		 * The dimension factory must be set before building a dimension type.
+		 *
+		 * @param factory a function creating new {@code Dimension} instances
+		 * @return this {@code Builder} object
+		 * @throws NullPointerException if {@code factory} is {@code null}
+		 */
+		public Builder factory(BiFunction<World, DimensionType, ? extends Dimension> factory) {
+			Preconditions.checkNotNull(factory);
+			this.factory = factory;
+			return this;
+		}
+
+		/**
+		 * Set whether built dimension types use skylight like the Overworld.
+		 * If this method is not called, the value defaults to {@code true}.
+		 *
+		 * @param skyLight {@code true} if the dimension of the built type should use skylight,
+		 * 		{@code false} otherwise
+		 * @return this {@code Builder} object
+		 */
+		public Builder skyLight(boolean skyLight) {
+			this.skyLight = skyLight;
+			return this;
+		}
+
+		/**
+		 * Sets this dimension's desired raw id.
+		 * If this method is not called, the value defaults to the raw registry id
+		 * of the dimension type.
+		 *
+		 * <p> A Fabric Dimension's desired raw id is used as its actual raw id
+		 * when it does not conflict with any existing id, and the world
+		 * save does not map the dimension to a different raw id.
+		 *
+		 * @param desiredRawId the new raw id for this dimension type
+		 * @return this {@code Builder} object
+		 * @apiNote Mods that used to have a dimension with a manually set id
+		 * may use this method to set a default id corresponding to the old one,
+		 * so as not to break compatibility with old worlds.
+		 */
+		public Builder desiredRawId(int desiredRawId) {
+			this.desiredRawId = desiredRawId;
+			return this;
+		}
+
+		/**
+		 * Build and register a {@code FabricDimensionType}.
+		 *
+		 * <p> The {@code dimensionId} is used as a registry ID, and as
+		 * a unique name both for the dimension suffix and the save directory.
+		 *
+		 * @param dimensionId the id used to name and register the dimension
+		 * @return the built {@code FabricDimensionType}
+		 * @throws IllegalArgumentException if an existing dimension has already been registered with {@code dimensionId}
+		 * @throws IllegalStateException    if no {@link #factory(BiFunction) factory} or {@link #defaultPlacer(EntityPlacer) default placer}
+		 *                                  have been set
+		 */
+		public FabricDimensionType buildAndRegister(Identifier dimensionId) {
+			Preconditions.checkArgument(!Registry.DIMENSION.containsId(dimensionId));
+			Preconditions.checkState(this.defaultPlacer != null, "No defaultPlacer has been specified!");
+			Preconditions.checkState(this.factory != null, "No dimension factory has been specified!");
+			String suffix = dimensionId.getNamespace() + "_" + dimensionId.getPath();
+			String saveDir = "DIM_" + dimensionId.getNamespace() + "_" + dimensionId.getPath();
+			FabricDimensionType built = new FabricDimensionType(suffix, saveDir, this.factory, this.defaultPlacer, this.skyLight);
+			Registry.register(Registry.DIMENSION, dimensionId, built);
+			if (this.desiredRawId != 0) {
+				built.desiredRawId = this.desiredRawId;
+			} else {
+				built.desiredRawId = Registry.DIMENSION.getRawId(built) - 1;
+			}
+			built.fixedRawId = built.desiredRawId;
+			return built;
+		}
+	}
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensionType.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensionType.java
@@ -204,7 +204,7 @@ public final class FabricDimensionType extends DimensionType {
 		 *                                  have been set
 		 */
 		public FabricDimensionType buildAndRegister(Identifier dimensionId) {
-			Preconditions.checkArgument(!Registry.DIMENSION.containsId(dimensionId));
+			Preconditions.checkArgument(Registry.DIMENSION.get(dimensionId) == null);
 			Preconditions.checkState(this.defaultPlacer != null, "No defaultPlacer has been specified!");
 			Preconditions.checkState(this.factory != null, "No dimension factory has been specified!");
 			String suffix = dimensionId.getNamespace() + "_" + dimensionId.getPath();

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensions.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensions.java
@@ -25,7 +25,9 @@ import net.minecraft.world.dimension.DimensionType;
  * This class consists exclusively of static methods that operate on world dimensions.
  */
 public final class FabricDimensions {
-	private FabricDimensions() { throw new AssertionError(); }
+	private FabricDimensions() {
+		throw new AssertionError();
+	}
 
 	/**
 	 * Teleports an entity to a different dimension, using custom placement logic.
@@ -72,11 +74,11 @@ public final class FabricDimensions {
 	 * <p> After calling this method, {@code teleported} may be invalidated. Callers should use
 	 * the returned entity for any further manipulation.
 	 *
-	 * @param teleported      the entity to teleport
-	 * @param destination     the dimension the entity will be teleported to
+	 * @param teleported   the entity to teleport
+	 * @param destination  the dimension the entity will be teleported to
 	 * @param customPlacer custom placement logic that will run before the default one,
-	 *                        or {@code null} to use the dimension's default behavior (see {@link FabricDimensionType#getDefaultPlacement()}).
-	 * @param <E>             the type of the teleported entity
+	 *                     or {@code null} to use the dimension's default behavior (see {@link FabricDimensionType#getDefaultPlacement()}).
+	 * @param <E>          the type of the teleported entity
 	 * @return the teleported entity, or a clone of it
 	 * @throws IllegalStateException if this method is called on a client entity
 	 * @apiNote this method must be called from the main server thread

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensions.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensions.java
@@ -1,5 +1,6 @@
 package net.fabricmc.fabric.api.dimension;
 
+import com.google.common.base.Preconditions;
 import net.fabricmc.fabric.impl.dimension.FabricDimensionInternals;
 import net.minecraft.entity.Entity;
 import net.minecraft.world.dimension.DimensionType;
@@ -57,12 +58,15 @@ public final class FabricDimensions {
 	 *
 	 * @param teleported      the entity to teleport
 	 * @param destination     the dimension the entity will be teleported to
-	 * @param customPlacement custom placement logic that will run before the default one,
+	 * @param customPlacer custom placement logic that will run before the default one,
 	 *                        or {@code null} to use the dimension's default behavior (see {@link FabricDimensionType#getDefaultPlacement()}).
 	 * @param <E>             the type of the teleported entity
 	 * @return the teleported entity, or a clone of it
+	 * @throws IllegalStateException if this method is called on a client entity
+	 * @apiNote this method must be called from the main server thread
 	 */
-	public static <E extends Entity> E teleport(E teleported, DimensionType destination, /*Nullable*/ EntityPlacer customPlacement) {
-		return FabricDimensionInternals.changeDimension(teleported, destination, customPlacement);
+	public static <E extends Entity> E teleport(E teleported, DimensionType destination, /*Nullable*/ EntityPlacer customPlacer) {
+		Preconditions.checkState(!teleported.world.isClient, "Entities can only be teleported on the server side");
+		return FabricDimensionInternals.changeDimension(teleported, destination, customPlacer);
 	}
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensions.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensions.java
@@ -8,35 +8,61 @@ import net.minecraft.world.dimension.DimensionType;
  * This class consists exclusively of static methods that operate on world dimensions.
  */
 public final class FabricDimensions {
-    private FabricDimensions() {
-        throw new AssertionError();
-    }
+	private FabricDimensions() { throw new AssertionError(); }
 
-    /**
-     * Teleports an entity to a different dimension, using custom placement logic.
-     *
-     * <p> If {@code customPlacement} is {@code null}, this method behaves as if:
-     * <pre>{@code teleported.changeDimension(destination)}</pre>
-     * The {@code customPlacement} may itself return {@code null}, in which case
-     * the default placement logic for that dimension will be run. If {@code destination}
-     * is a {@link FabricDimensionType}, that logic is {@link FabricDimensionType#getDefaultPlacement()}.
-     * If {@code destination} is the nether or the overworld, the default logic is the vanilla path.
-     * For any other dimension, the default placement behaviour is undefined.
-     * When delegating to a placement logic that uses portals, the entity's {@code lastPortalPosition},
-     * {@code lastPortalDirectionVector}, and {@code lastPortalDirection} fields should be updated
-     * before calling this method.
-     *
-     * <p> After calling this method, {@code teleported} may be invalidated. Callers should use
-     * the returned entity for any further manipulation.
-     *
-     * @param teleported      the entity to teleport
-     * @param destination     the dimension the entity will be teleported to
-     * @param customPlacement custom placement logic that will run before the default one,
-     *                        or {@code null} to use the dimension's default behavior (see {@link FabricDimensionType#getDefaultPlacement()}).
-     * @param <E>             the type of the teleported entity
-     * @return the teleported entity, or a clone of it
-     */
-    public static <E extends Entity> E teleport(E teleported, DimensionType destination, /*Nullable*/ EntityPlacer customPlacement) {
-        return FabricDimensionInternals.changeDimension(teleported, destination, customPlacement);
-    }
+	/**
+	 * Teleports an entity to a different dimension, using custom placement logic.
+	 *
+	 * <p> This method behaves as if:
+	 * <pre>{@code teleported.changeDimension(destination)}</pre>
+	 *
+	 * <p> If {@code destination} is a {@link FabricDimensionType}, the placement logic used
+	 * is {@link FabricDimensionType#getDefaultPlacement()}. If {@code destination} is
+	 * the nether or the overworld, the default logic is the vanilla path.
+	 * For any other dimension, the default placement behaviour is undefined.
+	 * When delegating to a placement logic that uses portals, the entity's {@code lastPortalPosition},
+	 * {@code lastPortalDirectionVector}, and {@code lastPortalDirection} fields should be updated
+	 * before calling this method.
+	 *
+	 * <p> After calling this method, {@code teleported} may be invalidated. Callers should use
+	 * the returned entity for any further manipulation.
+	 *
+	 * @param teleported  the entity to teleport
+	 * @param destination the dimension the entity will be teleported to
+	 * @return the teleported entity, or a clone of it
+	 * @see #teleport(Entity, DimensionType, EntityPlacer)
+	 */
+	public static <E extends Entity> E teleport(E teleported, DimensionType destination) {
+		return teleport(teleported, destination, null);
+	}
+
+	/**
+	 * Teleports an entity to a different dimension, using custom placement logic.
+	 *
+	 * <p> If {@code customPlacement} is {@code null}, this method behaves as if:
+	 * <pre>{@code teleported.changeDimension(destination)}</pre>
+	 * The {@code customPlacement} may itself return {@code null}, in which case
+	 * the default placement logic for that dimension will be run.
+	 *
+	 * <p> If {@code destination} is a {@link FabricDimensionType}, the default placement logic
+	 * is {@link FabricDimensionType#getDefaultPlacement()}. If {@code destination} is the nether
+	 * or the overworld, the default logic is the vanilla path.
+	 * For any other dimension, the default placement behaviour is undefined.
+	 * When delegating to a placement logic that uses portals, the entity's {@code lastPortalPosition},
+	 * {@code lastPortalDirectionVector}, and {@code lastPortalDirection} fields should be updated
+	 * before calling this method.
+	 *
+	 * <p> After calling this method, {@code teleported} may be invalidated. Callers should use
+	 * the returned entity for any further manipulation.
+	 *
+	 * @param teleported      the entity to teleport
+	 * @param destination     the dimension the entity will be teleported to
+	 * @param customPlacement custom placement logic that will run before the default one,
+	 *                        or {@code null} to use the dimension's default behavior (see {@link FabricDimensionType#getDefaultPlacement()}).
+	 * @param <E>             the type of the teleported entity
+	 * @return the teleported entity, or a clone of it
+	 */
+	public static <E extends Entity> E teleport(E teleported, DimensionType destination, /*Nullable*/ EntityPlacer customPlacement) {
+		return FabricDimensionInternals.changeDimension(teleported, destination, customPlacement);
+	}
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensions.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensions.java
@@ -23,7 +23,7 @@ public final class FabricDimensions {
      * If {@code destination} is the nether or the overworld, the default logic is the vanilla path.
      * For any other dimension, the default placement behaviour is undefined.
      * When delegating to a placement logic that uses portals, the entity's {@code lastPortalPosition},
-     * {@code lastPortalDirectionVector}, and {@code lastPortalDirection} fields should be updated 
+     * {@code lastPortalDirectionVector}, and {@code lastPortalDirection} fields should be updated
      * before calling this method.
      *
      * <p> After calling this method, {@code teleported} may be invalidated. Callers should use
@@ -32,7 +32,7 @@ public final class FabricDimensions {
      * @param teleported      the entity to teleport
      * @param destination     the dimension the entity will be teleported to
      * @param customPlacement custom placement logic that will run before the default one,
-     *                        or {@code null} for no custom placement.
+     *                        or {@code null} to use the dimension's default behavior (see {@link FabricDimensionType#getDefaultPlacement()}).
      * @param <E>             the type of the teleported entity
      * @return the teleported entity, or a clone of it
      */

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensions.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/api/dimension/FabricDimensions.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.api.dimension;
 
 import com.google.common.base.Preconditions;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsFixer.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsFixer.java
@@ -130,6 +130,7 @@ public class DimensionIdsFixer {
 	static {
 		try {
 			FABRIC_DIMENSION_TYPE$RAW_ID = FabricDimensionType.class.getDeclaredField("fixedRawId");
+			FABRIC_DIMENSION_TYPE$RAW_ID.setAccessible(true);
 		} catch (NoSuchFieldException e) {
 			throw new RuntimeException(e);
 		}

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsFixer.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsFixer.java
@@ -25,7 +25,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 /**
- * Handles fixing raw dimension ids between saves and servers
+ * Handles fixing raw dimension ids between saves and servers,
+ * and synchronizes said ids.
  */
 public class DimensionIdsFixer {
 	private static final Field FABRIC_DIMENSION_TYPE$RAW_ID;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsFixer.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsFixer.java
@@ -114,27 +114,7 @@ public class DimensionIdsFixer {
         return ServerSidePacketRegistry.INSTANCE.toPacket(ID, buf);
     }
 
-    static void receivePacket(PacketContext context, PacketByteBuf buf, Consumer<Exception> errorHandler) {
-        CompoundTag compound = buf.readCompoundTag();
-        try {
-            context.getTaskQueue().executeFuture(() -> {
-                if (compound == null) {
-                    errorHandler.accept(new RemapException("Received null compound tag in dimension sync packet!"));
-                    return null;
-                }
-                try {
-                    apply(compound);
-                } catch (RemapException e) {
-                    errorHandler.accept(e);
-                }
-                return null;
-            }).get(30, TimeUnit.SECONDS);
-        } catch (ExecutionException | InterruptedException | TimeoutException e) {
-            errorHandler.accept(e);
-        }
-    }
-
-    static {
+	static {
 		try {
 			FABRIC_DIMENSION_TYPE$RAW_ID = FabricDimensionType.class.getDeclaredField("fixedRawId");
 		} catch (NoSuchFieldException e) {

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsFixer.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsFixer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.impl.dimension;
 
 import io.netty.buffer.Unpooled;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsHolder.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsHolder.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.impl.dimension;
 
 import net.minecraft.nbt.CompoundTag;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsHolder.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionIdsHolder.java
@@ -22,5 +22,5 @@ import net.minecraft.nbt.CompoundTag;
  * An object holding a raw id -> full id map for fabric dimensions
  */
 public interface DimensionIdsHolder {
-    CompoundTag fabric_getDimensionIds();
+	CompoundTag fabric_getDimensionIds();
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionRemapException.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionRemapException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.impl.dimension;
 
 import net.fabricmc.fabric.impl.registry.RemapException;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionRemapException.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/DimensionRemapException.java
@@ -1,0 +1,9 @@
+package net.fabricmc.fabric.impl.dimension;
+
+import net.fabricmc.fabric.impl.registry.RemapException;
+
+public class DimensionRemapException extends RuntimeException {
+	public DimensionRemapException(String message, RemapException cause) {
+		super(message, cause);
+	}
+}

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionClientInit.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionClientInit.java
@@ -26,19 +26,14 @@ import net.minecraft.text.LiteralText;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Consumer;
-
 /**
  * Client entry point for fabric-dimensions
  */
 public final class FabricDimensionClientInit {
-    private static final Logger LOGGER = LogManager.getLogger();
+	private static final Logger LOGGER = LogManager.getLogger();
 
-    public static void onClientInit() {
-        ClientSidePacketRegistry.INSTANCE.register(DimensionIdsFixer.ID, (ctx, buf) -> {
+	public static void onClientInit() {
+		ClientSidePacketRegistry.INSTANCE.register(DimensionIdsFixer.ID, (ctx, buf) -> {
 			CompoundTag compound = buf.readCompoundTag();
 			ctx.getTaskQueue().execute(() -> {
 				if (compound == null) {
@@ -52,7 +47,7 @@ public final class FabricDimensionClientInit {
 				}
 			});
 		});
-    }
+	}
 
 	private static void handleError(PacketContext ctx, Exception e) {
 		LOGGER.error("Dimension id remapping failed!", e);

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionClientInit.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionClientInit.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.impl.dimension;
 
 import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionClientInit.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionClientInit.java
@@ -1,11 +1,19 @@
 package net.fabricmc.fabric.impl.dimension;
 
 import net.fabricmc.fabric.api.network.ClientSidePacketRegistry;
+import net.fabricmc.fabric.api.network.PacketContext;
+import net.fabricmc.fabric.impl.registry.RemapException;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.text.LiteralText;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 
 /**
  * Client entry point for fabric-dimensions
@@ -14,12 +22,27 @@ public final class FabricDimensionClientInit {
     private static final Logger LOGGER = LogManager.getLogger();
 
     public static void onClientInit() {
-        ClientSidePacketRegistry.INSTANCE.register(DimensionIdsFixer.ID, (ctx, buf) -> DimensionIdsFixer.receivePacket(ctx, buf, (e) -> {
-            LOGGER.error("Dimension id remapping failed!", e);
-            MinecraftClient.getInstance().execute(() -> ((ClientPlayerEntity) ctx.getPlayer()).networkHandler.getConnection().disconnect(
-                    new LiteralText("Dimension id remapping failed: " + e.getMessage())
-            ));
-        }));
+        ClientSidePacketRegistry.INSTANCE.register(DimensionIdsFixer.ID, (ctx, buf) -> {
+			CompoundTag compound = buf.readCompoundTag();
+			ctx.getTaskQueue().execute(() -> {
+				if (compound == null) {
+					handleError(ctx, new RemapException("Received null compound tag in dimension sync packet!"));
+					return;
+				}
+				try {
+					DimensionIdsFixer.apply(compound);
+				} catch (RemapException e) {
+					handleError(ctx, e);
+				}
+			});
+		});
     }
+
+	private static void handleError(PacketContext ctx, Exception e) {
+		LOGGER.error("Dimension id remapping failed!", e);
+		MinecraftClient.getInstance().execute(() -> ((ClientPlayerEntity) ctx.getPlayer()).networkHandler.getConnection().disconnect(
+			new LiteralText("Dimension id remapping failed: " + e)
+		));
+	}
 
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionInternals.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionInternals.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.impl.dimension;
 
 import com.google.common.base.Preconditions;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionInternals.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionInternals.java
@@ -19,6 +19,7 @@ package net.fabricmc.fabric.impl.dimension;
 import com.google.common.base.Preconditions;
 import net.fabricmc.fabric.api.dimension.EntityPlacer;
 import net.fabricmc.fabric.api.dimension.FabricDimensionType;
+import net.fabricmc.fabric.api.dimension.FabricDimensions;
 import net.fabricmc.fabric.mixin.EntityHooks;
 import net.minecraft.block.pattern.BlockPattern;
 import net.minecraft.entity.Entity;
@@ -27,82 +28,87 @@ import net.minecraft.util.math.Direction;
 import net.minecraft.world.dimension.DimensionType;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import net.fabricmc.fabric.api.dimension.FabricDimensions;
 
 public final class FabricDimensionInternals {
-    private FabricDimensionInternals() { throw new AssertionError(); }
+	private FabricDimensionInternals() {
+		throw new AssertionError();
+	}
 
-    public static final boolean DEBUG = System.getProperty("fabric.dimension.debug", "false").equalsIgnoreCase("true");
-    public static final Logger LOGGER = LogManager.getLogger();
+	public static final boolean DEBUG = System.getProperty("fabric.dimension.debug", "false").equalsIgnoreCase("true");
+	public static final Logger LOGGER = LogManager.getLogger();
 
-    /** The entity currently being transported to another dimension */
-    private static final ThreadLocal<Entity> PORTAL_ENTITY = new ThreadLocal<>();
-    /** The custom placement logic passed from {@link FabricDimensions#teleport(Entity, DimensionType, EntityPlacer)}*/
-    private static final ThreadLocal<EntityPlacer> CUSTOM_PLACEMENT = new ThreadLocal<>();
+	/**
+	 * The entity currently being transported to another dimension
+	 */
+	private static final ThreadLocal<Entity> PORTAL_ENTITY = new ThreadLocal<>();
+	/**
+	 * The custom placement logic passed from {@link FabricDimensions#teleport(Entity, DimensionType, EntityPlacer)}
+	 */
+	private static final ThreadLocal<EntityPlacer> CUSTOM_PLACEMENT = new ThreadLocal<>();
 
-    /*
-     * The dimension change hooks consist of two steps:
-     * - First, we memorize the currently teleported entity, and set required fields
-     * - Then, we retrieve the teleported entity in the placement logic in PortalForcer#getPortal
-     *   and use it to call the entity placers
-     * This lets us use the exact same logic for any entity and prevent the vanilla getPortal (which has unwanted
-     * side effects) from running, while keeping the patches minimally invasive.
-     *
-     * Shortcomings: bugs may arise if another patch cancels the teleportation method between
-     * #prepareDimensionalTeleportation and #tryFindPlacement, AND a mod calls PortalForcer#getPortal directly
-     * right after.
-     */
+	/*
+	 * The dimension change hooks consist of two steps:
+	 * - First, we memorize the currently teleported entity, and set required fields
+	 * - Then, we retrieve the teleported entity in the placement logic in PortalForcer#getPortal
+	 *   and use it to call the entity placers
+	 * This lets us use the exact same logic for any entity and prevent the vanilla getPortal (which has unwanted
+	 * side effects) from running, while keeping the patches minimally invasive.
+	 *
+	 * Shortcomings: bugs may arise if another patch cancels the teleportation method between
+	 * #prepareDimensionalTeleportation and #tryFindPlacement, AND a mod calls PortalForcer#getPortal directly
+	 * right after.
+	 */
 
-    public static void prepareDimensionalTeleportation(Entity entity) {
-        Preconditions.checkNotNull(entity);
-        PORTAL_ENTITY.set(entity);
-        // Set values used by `PortalForcer#changeDimension` to prevent a NPE crash.
-        EntityHooks access = ((EntityHooks) entity);
-        if (entity.getLastPortalDirectionVector() == null) {
-            access.setLastPortalDirectionVector(entity.getRotationVector());
-        }
-        if (entity.getLastPortalDirection() == null) {
-            access.setLastPortalDirection(entity.getHorizontalFacing());
-        }
-    }
+	public static void prepareDimensionalTeleportation(Entity entity) {
+		Preconditions.checkNotNull(entity);
+		PORTAL_ENTITY.set(entity);
+		// Set values used by `PortalForcer#changeDimension` to prevent a NPE crash.
+		EntityHooks access = ((EntityHooks) entity);
+		if (entity.getLastPortalDirectionVector() == null) {
+			access.setLastPortalDirectionVector(entity.getRotationVector());
+		}
+		if (entity.getLastPortalDirection() == null) {
+			access.setLastPortalDirection(entity.getHorizontalFacing());
+		}
+	}
 
-    /* Nullable */
-    public static BlockPattern.TeleportTarget tryFindPlacement(ServerWorld destination, Direction portalDir, double portalX, double portalY) {
-        Preconditions.checkNotNull(destination);
-        Entity teleported = PORTAL_ENTITY.get();
-        PORTAL_ENTITY.set(null);
-        // If the entity is null, the call does not come from a vanilla context
-        if (teleported == null) {
-            return null;
-        }
+	/* Nullable */
+	public static BlockPattern.TeleportTarget tryFindPlacement(ServerWorld destination, Direction portalDir, double portalX, double portalY) {
+		Preconditions.checkNotNull(destination);
+		Entity teleported = PORTAL_ENTITY.get();
+		PORTAL_ENTITY.set(null);
+		// If the entity is null, the call does not come from a vanilla context
+		if (teleported == null) {
+			return null;
+		}
 
-        // Custom placement logic, falls back to default dimension placement if no placement or target found
-        EntityPlacer customPlacement = CUSTOM_PLACEMENT.get();
-        if (customPlacement != null) {
-            BlockPattern.TeleportTarget customTarget = customPlacement.placeEntity(teleported, destination, portalDir, portalX, portalY);
-            if (customTarget != null) {
-                return customTarget;
-            }
-        }
+		// Custom placement logic, falls back to default dimension placement if no placement or target found
+		EntityPlacer customPlacement = CUSTOM_PLACEMENT.get();
+		if (customPlacement != null) {
+			BlockPattern.TeleportTarget customTarget = customPlacement.placeEntity(teleported, destination, portalDir, portalX, portalY);
+			if (customTarget != null) {
+				return customTarget;
+			}
+		}
 
-        // Default placement logic, falls back to vanilla if not a fabric dimension
-        DimensionType dimType = destination.getDimension().getType();
-        if (dimType instanceof FabricDimensionType) {
-            BlockPattern.TeleportTarget defaultTarget = ((FabricDimensionType) dimType).getDefaultPlacement().placeEntity(teleported, destination, portalDir, portalX, portalY);
-            if (defaultTarget == null) {
-                throw new IllegalStateException("Mod dimension " + DimensionType.getId(dimType) + " returned an invalid teleport target");
-            }
-            return defaultTarget;
-        }
+		// Default placement logic, falls back to vanilla if not a fabric dimension
+		DimensionType dimType = destination.getDimension().getType();
+		if (dimType instanceof FabricDimensionType) {
+			BlockPattern.TeleportTarget defaultTarget = ((FabricDimensionType) dimType).getDefaultPlacement().placeEntity(teleported, destination, portalDir, portalX, portalY);
+			if (defaultTarget == null) {
+				throw new IllegalStateException("Mod dimension " + DimensionType.getId(dimType) + " returned an invalid teleport target");
+			}
+			return defaultTarget;
+		}
 
-        // Vanilla / other implementations logic, undefined behaviour on custom dimensions
-        return null;
-    }
+		// Vanilla / other implementations logic, undefined behaviour on custom dimensions
+		return null;
+	}
 
-    @SuppressWarnings("unchecked")
-    public static <E extends Entity> E changeDimension(E teleported, DimensionType dimension, EntityPlacer placement) {
-    	assert !teleported.world.isClient : "Entities can only be teleported on the server side";
-		assert Thread.currentThread() == ((ServerWorld)teleported.world).getServer().getThread() : "Entities must be teleported from the main server thread";
+	@SuppressWarnings("unchecked")
+	public static <E extends Entity> E changeDimension(E teleported, DimensionType dimension, EntityPlacer placement) {
+		assert !teleported.world.isClient : "Entities can only be teleported on the server side";
+		assert Thread.currentThread() == ((ServerWorld) teleported.world).getServer().getThread() : "Entities must be teleported from the main server thread";
 		try {
 			CUSTOM_PLACEMENT.set(placement);
 			return (E) teleported.changeDimension(dimension);

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionInternals.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionInternals.java
@@ -44,7 +44,7 @@ public final class FabricDimensionInternals {
 	/**
 	 * The custom placement logic passed from {@link FabricDimensions#teleport(Entity, DimensionType, EntityPlacer)}
 	 */
-	private static final ThreadLocal<EntityPlacer> CUSTOM_PLACEMENT = new ThreadLocal<>();
+	private static EntityPlacer customPlacement;
 
 	/*
 	 * The dimension change hooks consist of two steps:
@@ -83,7 +83,7 @@ public final class FabricDimensionInternals {
 		}
 
 		// Custom placement logic, falls back to default dimension placement if no placement or target found
-		EntityPlacer customPlacement = CUSTOM_PLACEMENT.get();
+		EntityPlacer customPlacement = FabricDimensionInternals.customPlacement;
 		if (customPlacement != null) {
 			BlockPattern.TeleportTarget customTarget = customPlacement.placeEntity(teleported, destination, portalDir, portalX, portalY);
 			if (customTarget != null) {
@@ -110,10 +110,10 @@ public final class FabricDimensionInternals {
 		assert !teleported.world.isClient : "Entities can only be teleported on the server side";
 		assert Thread.currentThread() == ((ServerWorld) teleported.world).getServer().getThread() : "Entities must be teleported from the main server thread";
 		try {
-			CUSTOM_PLACEMENT.set(placement);
+			customPlacement = placement;
 			return (E) teleported.changeDimension(dimension);
 		} finally {
-			CUSTOM_PLACEMENT.set(null);
+			customPlacement = null;
 		}
 	}
 

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionInternals.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/impl/dimension/FabricDimensionInternals.java
@@ -85,12 +85,14 @@ public final class FabricDimensionInternals {
 
     @SuppressWarnings("unchecked")
     public static <E extends Entity> E changeDimension(E teleported, DimensionType dimension, EntityPlacer placement) {
-        try {
-            CUSTOM_PLACEMENT.set(placement);
-            return (E) teleported.changeDimension(dimension);
-        } finally {
-            CUSTOM_PLACEMENT.set(null);
-        }
-    }
+    	assert !teleported.world.isClient : "Entities can only be teleported on the server side";
+		assert Thread.currentThread() == ((ServerWorld)teleported.world).getServer().getThread() : "Entities must be teleported from the main server thread";
+		try {
+			CUSTOM_PLACEMENT.set(placement);
+			return (E) teleported.changeDimension(dimension);
+		} finally {
+			CUSTOM_PLACEMENT.set(null);
+		}
+	}
 
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/EntityHooks.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/EntityHooks.java
@@ -24,10 +24,10 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 
 @Mixin(Entity.class)
 public interface EntityHooks {
-    @Accessor
-    void setLastPortalDirectionVector(Vec3d vec);
+	@Accessor
+	void setLastPortalDirectionVector(Vec3d vec);
 
-    @Accessor
-    void setLastPortalDirection(Direction dir);
+	@Accessor
+	void setLastPortalDirection(Direction dir);
 
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/EntityHooks.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/EntityHooks.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin;
 
 import net.minecraft.entity.Entity;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/MixinEntity.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/MixinEntity.java
@@ -27,9 +27,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(Entity.class)
 public abstract class MixinEntity {
 
-    // Inject right before the direction vector is retrieved by the game
-    @Inject(method = "changeDimension", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;getLastPortalDirectionVector()Lnet/minecraft/util/math/Vec3d;"))
-    private void onGetPortal(DimensionType dimension, CallbackInfoReturnable<Entity> cir) {
-        FabricDimensionInternals.prepareDimensionalTeleportation((Entity)(Object)this);
-    }
+	// Inject right before the direction vector is retrieved by the game
+	@Inject(method = "changeDimension", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;getLastPortalDirectionVector()Lnet/minecraft/util/math/Vec3d;"))
+	private void onGetPortal(DimensionType dimension, CallbackInfoReturnable<Entity> cir) {
+		FabricDimensionInternals.prepareDimensionalTeleportation((Entity) (Object) this);
+	}
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/MixinEntity.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/MixinEntity.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin;
 
 import net.fabricmc.fabric.impl.dimension.FabricDimensionInternals;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/MixinPortalForcer.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/MixinPortalForcer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin;
 
 import net.fabricmc.fabric.impl.dimension.FabricDimensionInternals;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/MixinPortalForcer.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/MixinPortalForcer.java
@@ -33,18 +33,20 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(PortalForcer.class)
 public abstract class MixinPortalForcer {
-    @Shadow @Final private ServerWorld world;
+	@Shadow
+	@Final
+	private ServerWorld world;
 
-    @Inject(method = "usePortal", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;getLastPortalDirectionVector()Lnet/minecraft/util/math/Vec3d;"))
-    private void onUsePortal(Entity teleported, float yaw, CallbackInfoReturnable<Boolean> cir) {
-        FabricDimensionInternals.prepareDimensionalTeleportation(teleported);
-    }
+	@Inject(method = "usePortal", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;getLastPortalDirectionVector()Lnet/minecraft/util/math/Vec3d;"))
+	private void onUsePortal(Entity teleported, float yaw, CallbackInfoReturnable<Boolean> cir) {
+		FabricDimensionInternals.prepareDimensionalTeleportation(teleported);
+	}
 
-    @Inject(method = "getPortal", at = @At("HEAD"), cancellable = true)
-    private void findEntityPlacement(BlockPos pos, Vec3d velocity, Direction portalDir, double portalX, double portalY, boolean player, CallbackInfoReturnable<BlockPattern.TeleportTarget> cir) {
-        BlockPattern.TeleportTarget ret = FabricDimensionInternals.tryFindPlacement(this.world, portalDir, portalX, portalY);
-        if (ret != null) {
-            cir.setReturnValue(ret);
-        }
-    }
+	@Inject(method = "getPortal", at = @At("HEAD"), cancellable = true)
+	private void findEntityPlacement(BlockPos pos, Vec3d velocity, Direction portalDir, double portalX, double portalY, boolean player, CallbackInfoReturnable<BlockPattern.TeleportTarget> cir) {
+		BlockPattern.TeleportTarget ret = FabricDimensionInternals.tryFindPlacement(this.world, portalDir, portalX, portalY);
+		if (ret != null) {
+			cir.setReturnValue(ret);
+		}
+	}
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinDimensionRawIndexFix.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinDimensionRawIndexFix.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.idremap;
 
 import net.minecraft.util.registry.Registry;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinDimensionRawIndexFix.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinDimensionRawIndexFix.java
@@ -26,15 +26,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 // NOTE: This probably goes into dimension-fixes
 @Mixin(DimensionType.class)
 public abstract class MixinDimensionRawIndexFix {
-    @Inject(at = @At("RETURN"), method = "byRawId", cancellable = true)
-    private static void byRawId(final int id, final CallbackInfoReturnable<DimensionType> info) {
-        if (info.getReturnValue() == null || info.getReturnValue().getRawId() != id) {
-            for (DimensionType dimension : Registry.DIMENSION) {
-                if (dimension.getRawId() == id) {
-                    info.setReturnValue(dimension);
-                    return;
-                }
-            }
-        }
-    }
+	@Inject(at = @At("RETURN"), method = "byRawId", cancellable = true)
+	private static void byRawId(final int id, final CallbackInfoReturnable<DimensionType> info) {
+		if (info.getReturnValue() == null || info.getReturnValue().getRawId() != id) {
+			for (DimensionType dimension : Registry.DIMENSION) {
+				if (dimension.getRawId() == id) {
+					info.setReturnValue(dimension);
+					return;
+				}
+			}
+		}
+	}
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelProperties.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelProperties.java
@@ -31,26 +31,26 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(LevelProperties.class)
 public abstract class MixinLevelProperties implements DimensionIdsHolder {
-    @Unique
-    private CompoundTag fabricDimensionIds = new CompoundTag();
+	@Unique
+	private CompoundTag fabricDimensionIds = new CompoundTag();
 
-    @Override
-    public CompoundTag fabric_getDimensionIds() {
-        return fabricDimensionIds;
-    }
+	@Override
+	public CompoundTag fabric_getDimensionIds() {
+		return fabricDimensionIds;
+	}
 
-    @Inject(method = "<init>(Lnet/minecraft/nbt/CompoundTag;Lcom/mojang/datafixers/DataFixer;ILnet/minecraft/nbt/CompoundTag;)V", at = @At("RETURN"))
-    private void readDimensionIds(CompoundTag data, DataFixer fixer, int version, CompoundTag player, CallbackInfo ci) {
-        CompoundTag savedIds = data.getCompound("fabric_DimensionIds");
-        try {
-            this.fabricDimensionIds = DimensionIdsFixer.apply(savedIds);
-        } catch (RemapException e) {
-            throw new DimensionRemapException("Failed to assign unique dimension ids!", e);
-        }
-    }
+	@Inject(method = "<init>(Lnet/minecraft/nbt/CompoundTag;Lcom/mojang/datafixers/DataFixer;ILnet/minecraft/nbt/CompoundTag;)V", at = @At("RETURN"))
+	private void readDimensionIds(CompoundTag data, DataFixer fixer, int version, CompoundTag player, CallbackInfo ci) {
+		CompoundTag savedIds = data.getCompound("fabric_DimensionIds");
+		try {
+			this.fabricDimensionIds = DimensionIdsFixer.apply(savedIds);
+		} catch (RemapException e) {
+			throw new DimensionRemapException("Failed to assign unique dimension ids!", e);
+		}
+	}
 
-    @Inject(method = "updateProperties", at = @At("RETURN"))
-    private void writeDimensionIds(CompoundTag data, CompoundTag player, CallbackInfo ci) {
-        data.put("fabric_DimensionIds", fabricDimensionIds);
-    }
+	@Inject(method = "updateProperties", at = @At("RETURN"))
+	private void writeDimensionIds(CompoundTag data, CompoundTag player, CallbackInfo ci) {
+		data.put("fabric_DimensionIds", fabricDimensionIds);
+	}
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelProperties.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelProperties.java
@@ -3,6 +3,7 @@ package net.fabricmc.fabric.mixin.idremap;
 import com.mojang.datafixers.DataFixer;
 import net.fabricmc.fabric.impl.dimension.DimensionIdsFixer;
 import net.fabricmc.fabric.impl.dimension.DimensionIdsHolder;
+import net.fabricmc.fabric.impl.dimension.DimensionRemapException;
 import net.fabricmc.fabric.impl.registry.RemapException;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.world.level.LevelProperties;
@@ -28,7 +29,7 @@ public abstract class MixinLevelProperties implements DimensionIdsHolder {
         try {
             this.fabricDimensionIds = DimensionIdsFixer.apply(savedIds);
         } catch (RemapException e) {
-            throw new RuntimeException("Failed to assign unique dimension ids!", e);
+            throw new DimensionRemapException("Failed to assign unique dimension ids!", e);
         }
     }
 

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelProperties.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelProperties.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.idremap;
 
 import com.mojang.datafixers.DataFixer;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelStorage.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelStorage.java
@@ -24,7 +24,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Mixin(LevelStorage.class)
 public abstract class MixinLevelStorage {
-	@ModifyArg(method = "readLevelProperties", at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;error(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", remap = false), index = 1)
+	@ModifyArg(method = "readLevelProperties", at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;error(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", remap = false), index = 2)
 	private static Object disableRecovery(Object e) {
 		if (e instanceof DimensionRemapException) {
 			throw (DimensionRemapException) e;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelStorage.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelStorage.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.idremap;
 
 import net.fabricmc.fabric.impl.dimension.DimensionRemapException;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelStorage.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinLevelStorage.java
@@ -1,0 +1,18 @@
+package net.fabricmc.fabric.mixin.idremap;
+
+import net.fabricmc.fabric.impl.dimension.DimensionRemapException;
+import net.minecraft.world.level.storage.LevelStorage;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(LevelStorage.class)
+public abstract class MixinLevelStorage {
+	@ModifyArg(method = "readLevelProperties", at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;error(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V", remap = false), index = 1)
+	private static Object disableRecovery(Object e) {
+		if (e instanceof DimensionRemapException) {
+			throw (DimensionRemapException) e;
+		}
+		return e;
+	}
+}

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinPlayerManager.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinPlayerManager.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.idremap;
 
 import net.fabricmc.fabric.impl.dimension.DimensionIdsFixer;

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinPlayerManager.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinPlayerManager.java
@@ -28,15 +28,15 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(PlayerManager.class)
 public abstract class MixinPlayerManager {
-    /**
-     * Synchronizes raw dimension ids to connecting players
-     */
-    @Inject(method = "onPlayerConnect", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/packet/DifficultyS2CPacket;<init>(Lnet/minecraft/world/Difficulty;Z)V"))
-    private void onPlayerConnect(ClientConnection conn, ServerPlayerEntity player, CallbackInfo info) {
-        // TODO: Refactor out into network + move dimension hook to event
-        // No need to send the packet if the player is using the same game instance (dimension types are static)
-        if (!player.server.isSinglePlayer() || !conn.isLocal() || FabricDimensionInternals.DEBUG) {
-            player.networkHandler.sendPacket(DimensionIdsFixer.createPacket(player.world.getLevelProperties()));
-        }
-    }
+	/**
+	 * Synchronizes raw dimension ids to connecting players
+	 */
+	@Inject(method = "onPlayerConnect", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/packet/DifficultyS2CPacket;<init>(Lnet/minecraft/world/Difficulty;Z)V"))
+	private void onPlayerConnect(ClientConnection conn, ServerPlayerEntity player, CallbackInfo info) {
+		// TODO: Refactor out into network + move dimension hook to event
+		// No need to send the packet if the player is using the same game instance (dimension types are static)
+		if (!player.server.isSinglePlayer() || !conn.isLocal() || FabricDimensionInternals.DEBUG) {
+			player.networkHandler.sendPacket(DimensionIdsFixer.createPacket(player.world.getLevelProperties()));
+		}
+	}
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinUnmodifiableLevelProperties.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinUnmodifiableLevelProperties.java
@@ -26,13 +26,15 @@ import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(UnmodifiableLevelProperties.class)
 public abstract class MixinUnmodifiableLevelProperties implements DimensionIdsHolder {
-    @Shadow @Final private LevelProperties properties;
+	@Shadow
+	@Final
+	private LevelProperties properties;
 
-    /**
-     * Delegates to the main level properties
-     */
-    @Override
-    public CompoundTag fabric_getDimensionIds() {
-        return ((DimensionIdsHolder) this.properties).fabric_getDimensionIds();
-    }
+	/**
+	 * Delegates to the main level properties
+	 */
+	@Override
+	public CompoundTag fabric_getDimensionIds() {
+		return ((DimensionIdsHolder) this.properties).fabric_getDimensionIds();
+	}
 }

--- a/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinUnmodifiableLevelProperties.java
+++ b/fabric-dimensions-v1/src/main/java/net/fabricmc/fabric/mixin/idremap/MixinUnmodifiableLevelProperties.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2016, 2017, 2018, 2019 FabricMC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.fabricmc.fabric.mixin.idremap;
 
 import net.fabricmc.fabric.impl.dimension.DimensionIdsHolder;

--- a/fabric-dimensions-v1/src/main/resources/fabric-dimensions-v1.mixins.json
+++ b/fabric-dimensions-v1/src/main/resources/fabric-dimensions-v1.mixins.json
@@ -8,6 +8,7 @@
     "MixinPortalForcer",
     "idremap.MixinDimensionRawIndexFix",
     "idremap.MixinLevelProperties",
+    "idremap.MixinLevelStorage",
     "idremap.MixinPlayerManager",
     "idremap.MixinUnmodifiableLevelProperties"
   ],

--- a/fabric-dimensions-v1/src/main/resources/fabric.mod.json
+++ b/fabric-dimensions-v1/src/main/resources/fabric.mod.json
@@ -5,7 +5,9 @@
   "license": "Apache-2.0",
   "depends": {
     "fabricloader": ">=0.4.0",
-    "fabric-api-base": "*"
+    "fabric-api-base": "*",
+    "fabric-registry-sync-v0": "*",
+    "fabric-networking-v0": "*"
   },
   "entrypoints": {
     "client": [


### PR DESCRIPTION
This PR fixes style issues as well as deeper mechanical concerns. 
I have not exhaustively tested it, so I would recommend doing some tests like registering multiple dimensions with the same ID, with and without the API before merging. 

Things to check:
- Conflicting raw IDs between fabric dimension that has been previously saved and a regular dimension should result in a crash with no corruption of the `level.dat`.
- Having a vanilla dimension registered on the client with the same raw ID as a fabric dimension on the server should result in a connection error.
- Connecting to a server where a fabric dimension has a different raw ID should update the dimension's raw ID on the client.